### PR TITLE
made compatible with Guzzle version ^7.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": ">=7.1.0",
-        "guzzlehttp/guzzle": "^6.0"
+        "guzzlehttp/guzzle": "^7.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.7",

--- a/src/Arbor/Api/Gateway/RestGateway.php
+++ b/src/Arbor/Api/Gateway/RestGateway.php
@@ -11,7 +11,7 @@ use Arbor\Model\ModelBase;
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\BadResponseException;
 use GuzzleHttp\Exception\ConnectException;
-use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Exception\TransferException;
 use GuzzleHttp\Handler\CurlHandler;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Middleware;
@@ -581,7 +581,7 @@ class RestGateway implements GatewayInterface
     private function createRetryHandler()
     {
         /** @noinspection PhpUnusedParameterInspection */
-        return function ($retries, Request $request, Response $response = null, RequestException $exception = null) {
+        return function ($retries, Request $request, Response $response = null, TransferException $exception = null) {
             if ($retries >= self::MAX_RETRIES) {
                 return false;
             }
@@ -604,10 +604,10 @@ class RestGateway implements GatewayInterface
     }
 
     /**
-     * @param RequestException|null $exception
+     * @param TransferException|null $exception
      * @return bool
      */
-    private function isConnectError(RequestException $exception = null)
+    private function isConnectError(TransferException $exception = null)
     {
         return $exception instanceof ConnectException;
     }


### PR DESCRIPTION
The SDK is now compatible with Guzzle major version 7. I have updated the relevant breaking changes outlined here.

https://github.com/guzzle/guzzle/blob/7.0.0/UPGRADING.md#60-to-70

ConnectException is now inherited from TransferException instead of RequestException. RequestException is also inherited from TransferException so this won't break the closure returned from createRetryHandler. None of the other breaking changes are applicable.