### PR TITLE
MIS-46347: Allow redirects to https

### DIFF
--- a/src/Arbor/Api/Gateway/RestGateway.php
+++ b/src/Arbor/Api/Gateway/RestGateway.php
@@ -116,6 +116,7 @@ class RestGateway implements GatewayInterface
             'headers' => [
                 'User-Agent' => $this->getUserAgent(),
             ],
+            'allow_redirects' => ['strict' => true],
         ]);
         return $this;
     }


### PR DESCRIPTION
In case where api url is not https:// the server will redirect  but the guzzle client won't follow.
Surprisingly, it results with 401 error. 
Allowing redirects will make the system more tolerant for slightly misconfigured urls.