### PR TITLE
BIZOPS-4420 Handle 204 response fix

### DIFF
--- a/src/Arbor/Api/Gateway/RestGateway.php
+++ b/src/Arbor/Api/Gateway/RestGateway.php
@@ -646,7 +646,7 @@ class RestGateway implements GatewayInterface
             throw new ServerErrorException('An unexpected error has occurred: ' . $e->getMessage(), 0, $e);
         }
 
-        if (!is_array($responsePayload)) {
+        if (!is_array($responsePayload) && $code !== 204) {
             throw new ServerErrorException('Server responded with an invalid response', 0, null, $requestPayload);
         }
 
@@ -676,6 +676,7 @@ class RestGateway implements GatewayInterface
         switch ($code) {
             case 200:
             case 201:
+            case 204:
             case 422:
                 // Request succeeded or failed due to validation error(s), this is not an exception (return the response)
                 return $responsePayload;

--- a/src/Arbor/Api/Gateway/RestGateway.php
+++ b/src/Arbor/Api/Gateway/RestGateway.php
@@ -646,7 +646,7 @@ class RestGateway implements GatewayInterface
             throw new ServerErrorException('An unexpected error has occurred: ' . $e->getMessage(), 0, $e);
         }
 
-        if (!is_array($responsePayload) && $code !== 204) {
+        if (!is_array($responsePayload) && !$this->isResponseValid($code)) {
             throw new ServerErrorException('Server responded with an invalid response', 0, null, $requestPayload);
         }
 
@@ -694,6 +694,13 @@ class RestGateway implements GatewayInterface
         }
 
         throw $exception;
+    }
+
+    private function isResponseValid(int $code): bool
+    {
+        $validCodes = [200, 201, 204, 422];
+
+        return in_array($code, $validCodes);
     }
 
     /**

--- a/src/Arbor/Api/Gateway/RestGateway.php
+++ b/src/Arbor/Api/Gateway/RestGateway.php
@@ -679,7 +679,7 @@ class RestGateway implements GatewayInterface
             case 204:
             case 422:
                 // Request succeeded or failed due to validation error(s), this is not an exception (return the response)
-                return $responsePayload;
+                return $responsePayload ?? [];
             case 404:
                 $exception = new ResourceNotFoundException($message);
                 break;


### PR DESCRIPTION
When deleting something from CRM, the SIS returns code 204 with NO CONTENT. This results in error being thrown in CRM. This fix will handle 204 properly and avoid unnecessary exceptions.

TICKET: https://orchard.atlassian.net/browse/BIZOPS-4420