### PR TITLE
MIG-17813 Add support for uploading a file through SIS SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,31 @@ This will set the default gateway for all models, allowing you to use the SDK wi
 ```
 Use `Arbor\Api\Gateway\PsrRestGateway` to make GET, POST, PUT and DELETE requests and use `Arbor\Query\Query` to add filters to your requests.
 
+#### Multipart upload request
+
+Use the `upload()` method to submit files as `multipart/form-data`.
+
 ```php
+use Arbor\Api\Gateway\UploadFile;
+
+$fileContent = file_get_contents('/path/to/document.pdf');
+
+$response = $api->upload(
+    '/rest-v2/documents/upload',
+    new UploadFile(name: 'file', contents: $fileContent, filename: 'document.pdf')
+);
+```
+
+For large files, pass a PSR-7 stream to avoid loading the entire file into memory:
+
+```php
+$stream = $streamFactory->createStreamFromFile('/path/to/large-video.mp4');
+
+$response = $api->upload(
+    '/rest-v2/documents/upload',
+    new UploadFile(name: 'file', contents: $stream, filename: 'large-video.mp4')
+);
+```
 
 #### GET request:
 ```php

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ $response = $api->upload(
 For large files, pass a PSR-7 stream to avoid loading the entire file into memory:
 
 ```php
+// $streamFactory can be any PSR-17 StreamFactoryInterface implementation
 $stream = $streamFactory->createStreamFromFile('/path/to/large-video.mp4');
 
 $response = $api->upload(

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,8 @@
         "psr/http-message": "^2.0",
         "psr/http-factory": "^1.0",
         "nyholm/psr7": "^1.8",
-        "ext-mbstring": "*"
+        "ext-mbstring": "*",
+        "php-http/multipart-stream-builder": "^1.4"
     },
     "require-dev": {
         "phpunit/phpunit": "10.*",

--- a/src/Arbor/Api/Gateway/GatewayInterface.php
+++ b/src/Arbor/Api/Gateway/GatewayInterface.php
@@ -67,6 +67,13 @@ interface GatewayInterface
     public function bulkCreate(string $resource, Collection $collection, bool $checkForPersistence = true): Collection;
 
     /**
+     * @param string $endpoint
+     * @param UploadFile $file
+     * @return array
+     */
+    public function upload(string $endpoint, UploadFile $file): array;
+
+    /**
      * @param string $applicationId
      */
     public function setApplicationId(string $applicationId);

--- a/src/Arbor/Api/Gateway/HttpClient/HttpClient.php
+++ b/src/Arbor/Api/Gateway/HttpClient/HttpClient.php
@@ -8,6 +8,8 @@ use Arbor\Api\Exception\ResourceNotFoundException;
 use Arbor\Api\Exception\ServerErrorException;
 use Http\Discovery\Psr17FactoryDiscovery;
 use Http\Discovery\Psr18ClientDiscovery;
+use Http\Message\MultipartStream\MultipartStreamBuilder;
+use InvalidArgumentException;
 use Psr\Http\Client\ClientExceptionInterface;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestInterface;
@@ -157,6 +159,10 @@ class HttpClient implements HttpClientInterface
     {
         // NOTE: Uncomment this line to allow you to trigger a debug session in the Mis project
         // $url .= '?XDEBUG_SESSION_START=0';
+        if (array_key_exists('body', $options) && array_key_exists('multipart', $options)) {
+            throw new InvalidArgumentException('Cannot use "body" and "multipart" options in the same request.');
+        }
+
         // Handle query parameters by appending them to the URL
         if (!empty($options['query']) && is_array($options['query'])) {
             $queryString = http_build_query($options['query']);
@@ -166,6 +172,7 @@ class HttpClient implements HttpClientInterface
         }
 
         $request = $this->typedRequestFactory->createRequest($method, $this->baseUrl . $url);
+        $requestPayload = null;
 
         // Adding user agent string if it's not passed
         $options['headers']['User-Agent'] = $options['headers']['User-Agent'] ?? $this->userAgent;
@@ -186,8 +193,37 @@ class HttpClient implements HttpClientInterface
             $request = $request->withHeader('Authorization', $header);
         }
 
-        $requestPayload = $options['body'] ?? null;
-        if (is_array($requestPayload)) {
+        if (array_key_exists('multipart', $options)) {
+            $requestPayload = '[multipart data]';
+            $builder = new MultipartStreamBuilder($this->streamFactory);
+
+            foreach ($options['multipart'] as $index => $part) {
+                if (!isset($part['name']) || !is_scalar($part['name']) || $part['name'] === '') {
+                    throw new InvalidArgumentException(
+                        sprintf('Multipart part at index %d must contain non-empty scalar "name".', $index)
+                    );
+                }
+                if (!array_key_exists('contents', $part)) {
+                    throw new InvalidArgumentException(
+                        sprintf('Multipart part at index %d must contain "contents".', $index)
+                    );
+                }
+
+                $partOptions = [];
+                if (isset($part['filename'])) {
+                    $partOptions['filename'] = $part['filename'];
+                }
+                if (isset($part['headers'])) {
+                    $partOptions['headers'] = $part['headers'];
+                }
+                $builder->addResource($part['name'], $part['contents'], $partOptions);
+            }
+
+            $request = $request
+                ->withHeader('Content-Type', 'multipart/form-data; boundary="' . $builder->getBoundary() . '"')
+                ->withBody($builder->build());
+        } elseif (is_array($options['body'] ?? null)) {
+            $requestPayload = $options['body'];
             $bodyStream = $this->streamFactory->createStream(json_encode($requestPayload));
             $request = $request->withBody($bodyStream);
         }

--- a/src/Arbor/Api/Gateway/HttpClient/HttpClient.php
+++ b/src/Arbor/Api/Gateway/HttpClient/HttpClient.php
@@ -6,10 +6,10 @@ namespace Arbor\Api\Gateway\HttpClient;
 
 use Arbor\Api\Exception\ResourceNotFoundException;
 use Arbor\Api\Exception\ServerErrorException;
+use Arbor\Api\Gateway\UploadFile;
 use Http\Discovery\Psr17FactoryDiscovery;
 use Http\Discovery\Psr18ClientDiscovery;
 use Http\Message\MultipartStream\MultipartStreamBuilder;
-use InvalidArgumentException;
 use Psr\Http\Client\ClientExceptionInterface;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestInterface;
@@ -104,50 +104,7 @@ class HttpClient implements HttpClientInterface
         /** @var RequestInterface $request */
         list($request, $requestPayload) = $this->prepareRequest($method, $url, $options);
 
-        try {
-            $response = $this->httpClient->sendRequest($request);
-
-            // Allow the user to direct requests at a common API endpoint if they specify the applicationId as a request header
-            $response->getBody()->rewind();
-            $responsePayload = json_decode($response->getBody()->getContents(), true);
-        } catch (ClientExceptionInterface|RuntimeException $e) {
-            // Default to using the code and message from the Guzzle exception.
-            // This is useful in case the response does not contain valid json
-            throw new ServerErrorException('An unexpected error has occurred: ' . $e->getMessage(), 0, $e);
-        }
-
-        $code = $response->getStatusCode();
-
-        if (!is_array($responsePayload) && !$this->isResponseValid($code)) {
-            throw new ServerErrorException('Server responded with an invalid response', 0, null, $requestPayload);
-        }
-
-        // If the response has a code property
-        if (isset($responsePayload['response']['code'])) {
-            $code = $responsePayload['response']['code'];
-        }
-
-        // If available use the reason phrase
-        $message = $responsePayload['response']['reason'] ?? 'API Error';
-
-        // If available use a specific error message
-        $serverMessage = $serverTrace = $serverException = null;
-
-        if (isset($responsePayload['response']['errors']) &&
-            is_array($responsePayload['response']['errors']) &&
-            count($responsePayload['response']['errors'])
-        ) {
-            $serverException = $responsePayload['response']['errors'][0]['exception'];
-            $serverMessage = $responsePayload['response']['errors'][0]['message'];
-            $serverTrace = $responsePayload['response']['errors'][0]['trace'];
-            $message = sprintf("Server threw: %s with message: %s URL=%s", $serverException, $serverMessage, $url);
-        }
-
-        return match ($code) {
-            200, 201, 204, 422 => $responsePayload ?? [],
-            404 => throw new ResourceNotFoundException($message ?? 'Not Found'),
-            default => throw $this->getErrorException($message, $requestPayload, $responsePayload, $serverException, $serverMessage, $serverTrace),
-        };
+        return $this->executeRequest($request, $requestPayload);
     }
 
     protected function isResponseValid(int $code): bool
@@ -155,14 +112,34 @@ class HttpClient implements HttpClientInterface
         return in_array($code, [200, 201, 204, 422]);
     }
 
-    protected function prepareRequest(string $method, string $url, array $options): array
+    /**
+     * @throws ServerErrorException
+     */
+    public function uploadRequest(string $url, UploadFile $file, array $options = []): array
     {
-        // NOTE: Uncomment this line to allow you to trigger a debug session in the Mis project
-        // $url .= '?XDEBUG_SESSION_START=0';
-        if (array_key_exists('body', $options) && array_key_exists('multipart', $options)) {
-            throw new InvalidArgumentException('Cannot use "body" and "multipart" options in the same request.');
+        $request = $this->prepareBaseRequest(self::HTTP_METHOD_POST, $url, $options);
+
+        $builder = new MultipartStreamBuilder($this->streamFactory);
+
+        $partOptions = [];
+        if ($file->filename !== null) {
+            $partOptions['filename'] = $file->filename;
+        }
+        if ($file->headers !== null) {
+            $partOptions['headers'] = $file->headers;
         }
 
+        $builder->addResource($file->name, $file->contents, $partOptions);
+
+        $request = $request
+            ->withHeader('Content-Type', 'multipart/form-data; boundary="' . $builder->getBoundary() . '"')
+            ->withBody($builder->build());
+
+        return $this->executeRequest($request, '[multipart data]');
+    }
+
+    protected function prepareBaseRequest(string $method, string $url, array $options): RequestInterface
+    {
         // Handle query parameters by appending them to the URL
         if (!empty($options['query']) && is_array($options['query'])) {
             $queryString = http_build_query($options['query']);
@@ -172,7 +149,6 @@ class HttpClient implements HttpClientInterface
         }
 
         $request = $this->typedRequestFactory->createRequest($method, $this->baseUrl . $url);
-        $requestPayload = null;
 
         // Adding user agent string if it's not passed
         $options['headers']['User-Agent'] = $options['headers']['User-Agent'] ?? $this->userAgent;
@@ -193,42 +169,66 @@ class HttpClient implements HttpClientInterface
             $request = $request->withHeader('Authorization', $header);
         }
 
-        if (array_key_exists('multipart', $options)) {
-            $requestPayload = '[multipart data]';
-            $builder = new MultipartStreamBuilder($this->streamFactory);
+        return $request;
+    }
 
-            foreach ($options['multipart'] as $index => $part) {
-                if (!isset($part['name']) || !is_scalar($part['name']) || $part['name'] === '') {
-                    throw new InvalidArgumentException(
-                        sprintf('Multipart part at index %d must contain non-empty scalar "name".', $index)
-                    );
-                }
-                if (!array_key_exists('contents', $part)) {
-                    throw new InvalidArgumentException(
-                        sprintf('Multipart part at index %d must contain "contents".', $index)
-                    );
-                }
+    protected function prepareRequest(string $method, string $url, array $options): array
+    {
+        $request = $this->prepareBaseRequest($method, $url, $options);
+        $requestPayload = null;
 
-                $partOptions = [];
-                if (isset($part['filename'])) {
-                    $partOptions['filename'] = $part['filename'];
-                }
-                if (isset($part['headers'])) {
-                    $partOptions['headers'] = $part['headers'];
-                }
-                $builder->addResource($part['name'], $part['contents'], $partOptions);
-            }
-
-            $request = $request
-                ->withHeader('Content-Type', 'multipart/form-data; boundary="' . $builder->getBoundary() . '"')
-                ->withBody($builder->build());
-        } elseif (is_array($options['body'] ?? null)) {
+        if (is_array($options['body'] ?? null)) {
             $requestPayload = $options['body'];
             $bodyStream = $this->streamFactory->createStream(json_encode($requestPayload));
             $request = $request->withBody($bodyStream);
         }
 
         return [$request, $requestPayload];
+    }
+
+    /**
+     * @throws ServerErrorException
+     */
+    protected function executeRequest(RequestInterface $request, mixed $requestPayload): array
+    {
+        try {
+            $response = $this->httpClient->sendRequest($request);
+
+            $response->getBody()->rewind();
+            $responsePayload = json_decode($response->getBody()->getContents(), true);
+        } catch (ClientExceptionInterface|RuntimeException $e) {
+            throw new ServerErrorException('An unexpected error has occurred: ' . $e->getMessage(), 0, $e);
+        }
+
+        $code = $response->getStatusCode();
+
+        if (!is_array($responsePayload) && !$this->isResponseValid($code)) {
+            throw new ServerErrorException('Server responded with an invalid response', 0, null, $requestPayload);
+        }
+
+        if (isset($responsePayload['response']['code'])) {
+            $code = $responsePayload['response']['code'];
+        }
+
+        $message = $responsePayload['response']['reason'] ?? 'API Error';
+
+        $serverMessage = $serverTrace = $serverException = null;
+
+        if (isset($responsePayload['response']['errors']) &&
+            is_array($responsePayload['response']['errors']) &&
+            count($responsePayload['response']['errors'])
+        ) {
+            $serverException = $responsePayload['response']['errors'][0]['exception'];
+            $serverMessage = $responsePayload['response']['errors'][0]['message'];
+            $serverTrace = $responsePayload['response']['errors'][0]['trace'];
+            $message = sprintf("Server threw: %s with message: %s URL=%s", $serverException, $serverMessage, (string) $request->getUri());
+        }
+
+        return match ($code) {
+            200, 201, 204, 422 => $responsePayload ?? [],
+            404 => throw new ResourceNotFoundException($message ?? 'Not Found'),
+            default => throw $this->getErrorException($message, $requestPayload, $responsePayload, $serverException, $serverMessage, $serverTrace),
+        };
     }
 
     protected function getErrorException($message, $requestPayload, $responsePayload, $serverException, $serverMessage, $serverTrace): ServerErrorException

--- a/src/Arbor/Api/Gateway/HttpClient/HttpClientInterface.php
+++ b/src/Arbor/Api/Gateway/HttpClient/HttpClientInterface.php
@@ -3,6 +3,7 @@
 namespace Arbor\Api\Gateway\HttpClient;
 
 use Arbor\Api\Exception\ServerErrorException;
+use Arbor\Api\Gateway\UploadFile;
 
 interface HttpClientInterface
 {
@@ -39,4 +40,13 @@ interface HttpClientInterface
      * @throws ServerErrorException
      */
     public function sendRequest(string $method, string $url, array $options = []): array;
+
+    /**
+     * @param string $url
+     * @param UploadFile $file
+     * @param array $options Optional options (e.g. 'query', 'headers')
+     * @return array
+     * @throws ServerErrorException
+     */
+    public function uploadRequest(string $url, UploadFile $file, array $options = []): array;
 }

--- a/src/Arbor/Api/Gateway/PsrRestGateway.php
+++ b/src/Arbor/Api/Gateway/PsrRestGateway.php
@@ -312,6 +312,31 @@ class PsrRestGateway implements GatewayInterface
         return $this->httpClient->sendRequest(HttpClientInterface::HTTP_METHOD_DELETE, $model->getResourceUrl());
     }
 
+    /**
+     * @throws ServerErrorException
+     */
+    public function upload(string $endpoint, UploadFile $file): array
+    {
+        $part = [
+            'name' => $file->name,
+            'contents' => $file->contents,
+        ];
+
+        if ($file->filename !== null) {
+            $part['filename'] = $file->filename;
+        }
+
+        if ($file->headers !== null) {
+            $part['headers'] = $file->headers;
+        }
+
+        return $this->httpClient->sendRequest(
+            HttpClientInterface::HTTP_METHOD_POST,
+            $endpoint,
+            ['multipart' => [$part]]
+        );
+    }
+
     public function describe($resource): void
     {
         // This method is not implemented and should be removed in future

--- a/src/Arbor/Api/Gateway/PsrRestGateway.php
+++ b/src/Arbor/Api/Gateway/PsrRestGateway.php
@@ -317,24 +317,7 @@ class PsrRestGateway implements GatewayInterface
      */
     public function upload(string $endpoint, UploadFile $file): array
     {
-        $part = [
-            'name' => $file->name,
-            'contents' => $file->contents,
-        ];
-
-        if ($file->filename !== null) {
-            $part['filename'] = $file->filename;
-        }
-
-        if ($file->headers !== null) {
-            $part['headers'] = $file->headers;
-        }
-
-        return $this->httpClient->sendRequest(
-            HttpClientInterface::HTTP_METHOD_POST,
-            $endpoint,
-            ['multipart' => [$part]]
-        );
+        return $this->httpClient->uploadRequest($endpoint, $file);
     }
 
     public function describe($resource): void

--- a/src/Arbor/Api/Gateway/UploadFile.php
+++ b/src/Arbor/Api/Gateway/UploadFile.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Arbor\Api\Gateway;
+
+use Psr\Http\Message\StreamInterface;
+
+class UploadFile
+{
+    public function __construct(
+        public readonly string $name,
+        public readonly string|StreamInterface $contents,
+        public readonly ?string $filename = null,
+        public readonly ?array $headers = null,
+    ) {
+    }
+}

--- a/tests/Unit/Arbor/Api/Gateway/HttpClient/HttpClientTest.php
+++ b/tests/Unit/Arbor/Api/Gateway/HttpClient/HttpClientTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Arbor\Test\Unit\Arbor\Api\Gateway\HttpClient;
 
+use InvalidArgumentException;
+use Nyholm\Psr7\Factory\Psr17Factory;
 use Arbor\Api\Exception\ResourceNotFoundException;
 use Arbor\Api\Exception\ServerErrorException;
 use Arbor\Api\Gateway\HttpClient\HttpClient;
@@ -11,7 +13,6 @@ use Arbor\Api\Gateway\HttpClient\HttpClientInterface;
 use Arbor\Api\Gateway\HttpClient\TypedRequest;
 use Arbor\Api\Gateway\HttpClient\TypedRequestFactory;
 use PHPUnit\Framework\Attributes\CoversClass;
-use PHPUnit\Framework\Attributes\CoversClassesThatImplementInterface;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\Exception;
 use PHPUnit\Framework\TestCase;
@@ -21,7 +22,8 @@ use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
 
 #[CoversClass(HttpClient::class)]
-#[CoversClassesThatImplementInterface(HttpClientInterface::class)]
+#[CoversClass(TypedRequest::class)]
+#[CoversClass(TypedRequestFactory::class)]
 class HttpClientTest extends TestCase
 {
     private ClientInterface $httpClientMock;
@@ -505,5 +507,301 @@ class HttpClientTest extends TestCase
         ]);
 
         $this->assertEquals(['response' => ['code' => 201]], $result);
+    }
+
+    /**
+     * @throws ServerErrorException
+     */
+    public function testSendsRequestWithMultipartData()
+    {
+        $psr17Factory = new Psr17Factory();
+        $httpClient = new HttpClient(
+            new TypedRequestFactory($psr17Factory),
+            $this->httpClientMock,
+            $psr17Factory
+        );
+
+        $this->responseMock
+            ->method('getStatusCode')
+            ->willReturn(200);
+
+        $this->responseMock
+            ->method('getBody')
+            ->willReturn($this->createConfiguredMock(StreamInterface::class, [
+                'getContents' => json_encode(['response' => ['code' => 200]])
+            ]));
+
+        $this->httpClientMock
+            ->expects($this->once())
+            ->method('sendRequest')
+            ->with($this->callback(function ($request): bool {
+                $request->getBody()->rewind();
+                $payload = $request->getBody()->getContents();
+
+                $this->assertSame('POST', $request->getMethod());
+                $this->assertStringStartsWith(
+                    'multipart/form-data; boundary=',
+                    $request->getHeaderLine('Content-Type')
+                );
+                $this->assertStringContainsString('Content-Disposition: form-data; name="file"; filename="upload.txt"', $payload);
+                $this->assertStringContainsString("Content-Type: text/plain\r\n", $payload);
+                $this->assertStringContainsString('hello-world', $payload);
+
+                return true;
+            }))
+            ->willReturn($this->responseMock);
+
+        $result = $httpClient->sendRequest(HttpClientInterface::HTTP_METHOD_POST, '/upload', [
+            'multipart' => [
+                [
+                    'name' => 'file',
+                    'filename' => 'upload.txt',
+                    'contents' => 'hello-world',
+                ],
+            ],
+        ]);
+
+        $this->assertEquals(['response' => ['code' => 200]], $result);
+    }
+
+    public function testMasksMultipartPayloadInServerErrorException(): void
+    {
+        $psr17Factory = new Psr17Factory();
+        $httpClient = new HttpClient(
+            new TypedRequestFactory($psr17Factory),
+            $this->httpClientMock,
+            $psr17Factory
+        );
+
+        $this->responseMock
+            ->method('getStatusCode')
+            ->willReturn(500);
+
+        $this->responseMock
+            ->method('getBody')
+            ->willReturn($this->createConfiguredMock(StreamInterface::class, [
+                'getContents' => json_encode(['response' => ['reason' => 'Server Error']])
+            ]));
+
+        $this->httpClientMock
+            ->expects($this->once())
+            ->method('sendRequest')
+            ->willReturn($this->responseMock);
+
+        try {
+            $httpClient->sendRequest(HttpClientInterface::HTTP_METHOD_POST, '/upload', [
+                'multipart' => [
+                    [
+                        'name' => 'file',
+                        'filename' => 'upload.txt',
+                        'contents' => 'binary-or-large-content',
+                    ],
+                ],
+            ]);
+            $this->fail('Expected ServerErrorException to be thrown.');
+        } catch (ServerErrorException $exception) {
+            $this->assertSame('[multipart data]', $exception->getRequestPayload());
+        }
+    }
+
+    /**
+     * @throws ServerErrorException
+     */
+    public function testSendsRequestWithMultipartAndQueryParameters()
+    {
+        $psr17Factory = new Psr17Factory();
+        $httpClient = new HttpClient(
+            new TypedRequestFactory($psr17Factory),
+            $this->httpClientMock,
+            $psr17Factory
+        );
+
+        $this->responseMock
+            ->method('getStatusCode')
+            ->willReturn(200);
+
+        $this->responseMock
+            ->method('getBody')
+            ->willReturn($this->createConfiguredMock(StreamInterface::class, [
+                'getContents' => json_encode(['response' => ['code' => 200]])
+            ]));
+
+        $this->httpClientMock
+            ->expects($this->once())
+            ->method('sendRequest')
+            ->with($this->callback(function ($request): bool {
+                $this->assertSame('/upload?folder=reports', (string) $request->getUri());
+                $this->assertStringStartsWith(
+                    'multipart/form-data; boundary=',
+                    $request->getHeaderLine('Content-Type')
+                );
+
+                return true;
+            }))
+            ->willReturn($this->responseMock);
+
+        $result = $httpClient->sendRequest(HttpClientInterface::HTTP_METHOD_POST, '/upload', [
+            'query' => [
+                'folder' => 'reports',
+            ],
+            'multipart' => [
+                [
+                    'name' => 'file',
+                    'filename' => 'report.csv',
+                    'contents' => 'row-1',
+                ],
+            ],
+        ]);
+
+        $this->assertEquals(['response' => ['code' => 200]], $result);
+    }
+
+    /**
+     * @throws ServerErrorException
+     */
+    public function testSendsRequestWithMultipleMultipartParts(): void
+    {
+        $psr17Factory = new Psr17Factory();
+        $httpClient = new HttpClient(
+            new TypedRequestFactory($psr17Factory),
+            $this->httpClientMock,
+            $psr17Factory
+        );
+
+        $this->responseMock
+            ->method('getStatusCode')
+            ->willReturn(200);
+
+        $this->responseMock
+            ->method('getBody')
+            ->willReturn($this->createConfiguredMock(StreamInterface::class, [
+                'getContents' => json_encode(['response' => ['code' => 200]])
+            ]));
+
+        $this->httpClientMock
+            ->expects($this->once())
+            ->method('sendRequest')
+            ->with($this->callback(function ($request): bool {
+                $request->getBody()->rewind();
+                $payload = $request->getBody()->getContents();
+
+                $this->assertStringContainsString('Content-Disposition: form-data; name="description"', $payload);
+                $this->assertStringContainsString('Student profile image', $payload);
+                $this->assertStringContainsString('Content-Disposition: form-data; name="file"; filename="avatar.png"', $payload);
+                $this->assertStringContainsString("Content-Type: image/png\r\n", $payload);
+                $this->assertStringContainsString('png-bytes', $payload);
+
+                return true;
+            }))
+            ->willReturn($this->responseMock);
+
+        $result = $httpClient->sendRequest(HttpClientInterface::HTTP_METHOD_POST, '/upload', [
+            'multipart' => [
+                [
+                    'name' => 'description',
+                    'contents' => 'Student profile image',
+                ],
+                [
+                    'name' => 'file',
+                    'filename' => 'avatar.png',
+                    'contents' => 'png-bytes',
+                ],
+            ],
+        ]);
+
+        $this->assertEquals(['response' => ['code' => 200]], $result);
+    }
+
+    public function testThrowsExceptionWhenBodyAndMultipartAreSet(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Cannot use "body" and "multipart" options in the same request.');
+
+        $this->httpClient->sendRequest(HttpClientInterface::HTTP_METHOD_POST, '/upload', [
+            'body' => ['key' => 'value'],
+            'multipart' => [
+                [
+                    'name' => 'file',
+                    'contents' => 'content',
+                ],
+            ],
+        ]);
+    }
+
+    public function testThrowsExceptionForMultipartWithoutRequiredFields(): void
+    {
+        $psr17Factory = new Psr17Factory();
+        $httpClient = new HttpClient(
+            new TypedRequestFactory($psr17Factory),
+            $this->httpClientMock,
+            $psr17Factory
+        );
+
+        $this->httpClientMock
+            ->expects($this->never())
+            ->method('sendRequest');
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Multipart part at index 0 must contain non-empty scalar "name".');
+
+        $httpClient->sendRequest(HttpClientInterface::HTTP_METHOD_POST, '/upload', [
+            'multipart' => [
+                [
+                    'contents' => 'content',
+                ],
+            ],
+        ]);
+    }
+
+    /**
+     * @throws ServerErrorException
+     */
+    public function testKeepsExplicitMultipartPartContentTypeHeader(): void
+    {
+        $psr17Factory = new Psr17Factory();
+        $httpClient = new HttpClient(
+            new TypedRequestFactory($psr17Factory),
+            $this->httpClientMock,
+            $psr17Factory
+        );
+
+        $this->responseMock
+            ->method('getStatusCode')
+            ->willReturn(200);
+
+        $this->responseMock
+            ->method('getBody')
+            ->willReturn($this->createConfiguredMock(StreamInterface::class, [
+                'getContents' => json_encode(['response' => ['code' => 200]])
+            ]));
+
+        $this->httpClientMock
+            ->expects($this->once())
+            ->method('sendRequest')
+            ->with($this->callback(function ($request): bool {
+                $request->getBody()->rewind();
+                $payload = $request->getBody()->getContents();
+
+                $this->assertStringContainsString("content-type: image/png\r\n", strtolower($payload));
+                $this->assertStringNotContainsString("Content-Type: application/octet-stream\r\n", $payload);
+
+                return true;
+            }))
+            ->willReturn($this->responseMock);
+
+        $result = $httpClient->sendRequest(HttpClientInterface::HTTP_METHOD_POST, '/upload', [
+            'multipart' => [
+                [
+                    'name' => 'file',
+                    'filename' => 'avatar.png',
+                    'contents' => 'png-bytes',
+                    'headers' => [
+                        'content-type' => 'image/png',
+                    ],
+                ],
+            ],
+        ]);
+
+        $this->assertEquals(['response' => ['code' => 200]], $result);
     }
 }

--- a/tests/Unit/Arbor/Api/Gateway/HttpClient/HttpClientTest.php
+++ b/tests/Unit/Arbor/Api/Gateway/HttpClient/HttpClientTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Arbor\Test\Unit\Arbor\Api\Gateway\HttpClient;
 
-use InvalidArgumentException;
 use Nyholm\Psr7\Factory\Psr17Factory;
 use Arbor\Api\Exception\ResourceNotFoundException;
 use Arbor\Api\Exception\ServerErrorException;
@@ -12,6 +11,7 @@ use Arbor\Api\Gateway\HttpClient\HttpClient;
 use Arbor\Api\Gateway\HttpClient\HttpClientInterface;
 use Arbor\Api\Gateway\HttpClient\TypedRequest;
 use Arbor\Api\Gateway\HttpClient\TypedRequestFactory;
+use Arbor\Api\Gateway\UploadFile;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\Exception;
@@ -512,7 +512,7 @@ class HttpClientTest extends TestCase
     /**
      * @throws ServerErrorException
      */
-    public function testSendsRequestWithMultipartData()
+    public function testUploadRequestSendsMultipartWithUploadFile(): void
     {
         $psr17Factory = new Psr17Factory();
         $httpClient = new HttpClient(
@@ -543,71 +543,23 @@ class HttpClientTest extends TestCase
                     'multipart/form-data; boundary=',
                     $request->getHeaderLine('Content-Type')
                 );
-                $this->assertStringContainsString('Content-Disposition: form-data; name="file"; filename="upload.txt"', $payload);
-                $this->assertStringContainsString("Content-Type: text/plain\r\n", $payload);
-                $this->assertStringContainsString('hello-world', $payload);
+                $this->assertStringContainsString('Content-Disposition: form-data; name="file"; filename="report.pdf"', $payload);
+                $this->assertStringContainsString('pdf-contents', $payload);
 
                 return true;
             }))
             ->willReturn($this->responseMock);
 
-        $result = $httpClient->sendRequest(HttpClientInterface::HTTP_METHOD_POST, '/upload', [
-            'multipart' => [
-                [
-                    'name' => 'file',
-                    'filename' => 'upload.txt',
-                    'contents' => 'hello-world',
-                ],
-            ],
-        ]);
+        $file = new UploadFile(name: 'file', contents: 'pdf-contents', filename: 'report.pdf');
+        $result = $httpClient->uploadRequest('/rest-v2/documents/upload', $file);
 
         $this->assertEquals(['response' => ['code' => 200]], $result);
-    }
-
-    public function testMasksMultipartPayloadInServerErrorException(): void
-    {
-        $psr17Factory = new Psr17Factory();
-        $httpClient = new HttpClient(
-            new TypedRequestFactory($psr17Factory),
-            $this->httpClientMock,
-            $psr17Factory
-        );
-
-        $this->responseMock
-            ->method('getStatusCode')
-            ->willReturn(500);
-
-        $this->responseMock
-            ->method('getBody')
-            ->willReturn($this->createConfiguredMock(StreamInterface::class, [
-                'getContents' => json_encode(['response' => ['reason' => 'Server Error']])
-            ]));
-
-        $this->httpClientMock
-            ->expects($this->once())
-            ->method('sendRequest')
-            ->willReturn($this->responseMock);
-
-        try {
-            $httpClient->sendRequest(HttpClientInterface::HTTP_METHOD_POST, '/upload', [
-                'multipart' => [
-                    [
-                        'name' => 'file',
-                        'filename' => 'upload.txt',
-                        'contents' => 'binary-or-large-content',
-                    ],
-                ],
-            ]);
-            $this->fail('Expected ServerErrorException to be thrown.');
-        } catch (ServerErrorException $exception) {
-            $this->assertSame('[multipart data]', $exception->getRequestPayload());
-        }
     }
 
     /**
      * @throws ServerErrorException
      */
-    public function testSendsRequestWithMultipartAndQueryParameters()
+    public function testUploadRequestWithQueryParameters(): void
     {
         $psr17Factory = new Psr17Factory();
         $httpClient = new HttpClient(
@@ -630,7 +582,7 @@ class HttpClientTest extends TestCase
             ->expects($this->once())
             ->method('sendRequest')
             ->with($this->callback(function ($request): bool {
-                $this->assertSame('/upload?folder=reports', (string) $request->getUri());
+                $this->assertSame('/rest-v2/documents/upload?folder=reports', (string) $request->getUri());
                 $this->assertStringStartsWith(
                     'multipart/form-data; boundary=',
                     $request->getHeaderLine('Content-Type')
@@ -640,17 +592,9 @@ class HttpClientTest extends TestCase
             }))
             ->willReturn($this->responseMock);
 
-        $result = $httpClient->sendRequest(HttpClientInterface::HTTP_METHOD_POST, '/upload', [
-            'query' => [
-                'folder' => 'reports',
-            ],
-            'multipart' => [
-                [
-                    'name' => 'file',
-                    'filename' => 'report.csv',
-                    'contents' => 'row-1',
-                ],
-            ],
+        $file = new UploadFile(name: 'file', contents: 'csv-data', filename: 'report.csv');
+        $result = $httpClient->uploadRequest('/rest-v2/documents/upload', $file, [
+            'query' => ['folder' => 'reports'],
         ]);
 
         $this->assertEquals(['response' => ['code' => 200]], $result);
@@ -659,104 +603,7 @@ class HttpClientTest extends TestCase
     /**
      * @throws ServerErrorException
      */
-    public function testSendsRequestWithMultipleMultipartParts(): void
-    {
-        $psr17Factory = new Psr17Factory();
-        $httpClient = new HttpClient(
-            new TypedRequestFactory($psr17Factory),
-            $this->httpClientMock,
-            $psr17Factory
-        );
-
-        $this->responseMock
-            ->method('getStatusCode')
-            ->willReturn(200);
-
-        $this->responseMock
-            ->method('getBody')
-            ->willReturn($this->createConfiguredMock(StreamInterface::class, [
-                'getContents' => json_encode(['response' => ['code' => 200]])
-            ]));
-
-        $this->httpClientMock
-            ->expects($this->once())
-            ->method('sendRequest')
-            ->with($this->callback(function ($request): bool {
-                $request->getBody()->rewind();
-                $payload = $request->getBody()->getContents();
-
-                $this->assertStringContainsString('Content-Disposition: form-data; name="description"', $payload);
-                $this->assertStringContainsString('Student profile image', $payload);
-                $this->assertStringContainsString('Content-Disposition: form-data; name="file"; filename="avatar.png"', $payload);
-                $this->assertStringContainsString("Content-Type: image/png\r\n", $payload);
-                $this->assertStringContainsString('png-bytes', $payload);
-
-                return true;
-            }))
-            ->willReturn($this->responseMock);
-
-        $result = $httpClient->sendRequest(HttpClientInterface::HTTP_METHOD_POST, '/upload', [
-            'multipart' => [
-                [
-                    'name' => 'description',
-                    'contents' => 'Student profile image',
-                ],
-                [
-                    'name' => 'file',
-                    'filename' => 'avatar.png',
-                    'contents' => 'png-bytes',
-                ],
-            ],
-        ]);
-
-        $this->assertEquals(['response' => ['code' => 200]], $result);
-    }
-
-    public function testThrowsExceptionWhenBodyAndMultipartAreSet(): void
-    {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Cannot use "body" and "multipart" options in the same request.');
-
-        $this->httpClient->sendRequest(HttpClientInterface::HTTP_METHOD_POST, '/upload', [
-            'body' => ['key' => 'value'],
-            'multipart' => [
-                [
-                    'name' => 'file',
-                    'contents' => 'content',
-                ],
-            ],
-        ]);
-    }
-
-    public function testThrowsExceptionForMultipartWithoutRequiredFields(): void
-    {
-        $psr17Factory = new Psr17Factory();
-        $httpClient = new HttpClient(
-            new TypedRequestFactory($psr17Factory),
-            $this->httpClientMock,
-            $psr17Factory
-        );
-
-        $this->httpClientMock
-            ->expects($this->never())
-            ->method('sendRequest');
-
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Multipart part at index 0 must contain non-empty scalar "name".');
-
-        $httpClient->sendRequest(HttpClientInterface::HTTP_METHOD_POST, '/upload', [
-            'multipart' => [
-                [
-                    'contents' => 'content',
-                ],
-            ],
-        ]);
-    }
-
-    /**
-     * @throws ServerErrorException
-     */
-    public function testKeepsExplicitMultipartPartContentTypeHeader(): void
+    public function testUploadRequestWithCustomHeaders(): void
     {
         $psr17Factory = new Psr17Factory();
         $httpClient = new HttpClient(
@@ -783,24 +630,94 @@ class HttpClientTest extends TestCase
                 $payload = $request->getBody()->getContents();
 
                 $this->assertStringContainsString("content-type: image/png\r\n", strtolower($payload));
-                $this->assertStringNotContainsString("Content-Type: application/octet-stream\r\n", $payload);
 
                 return true;
             }))
             ->willReturn($this->responseMock);
 
-        $result = $httpClient->sendRequest(HttpClientInterface::HTTP_METHOD_POST, '/upload', [
-            'multipart' => [
-                [
-                    'name' => 'file',
-                    'filename' => 'avatar.png',
-                    'contents' => 'png-bytes',
-                    'headers' => [
-                        'content-type' => 'image/png',
-                    ],
-                ],
-            ],
-        ]);
+        $file = new UploadFile(
+            name: 'file',
+            contents: 'png-bytes',
+            filename: 'avatar.png',
+            headers: ['Content-Type' => 'image/png']
+        );
+        $result = $httpClient->uploadRequest('/rest-v2/documents/upload', $file);
+
+        $this->assertEquals(['response' => ['code' => 200]], $result);
+    }
+
+    public function testUploadRequestMasksPayloadInServerErrorException(): void
+    {
+        $psr17Factory = new Psr17Factory();
+        $httpClient = new HttpClient(
+            new TypedRequestFactory($psr17Factory),
+            $this->httpClientMock,
+            $psr17Factory
+        );
+
+        $this->responseMock
+            ->method('getStatusCode')
+            ->willReturn(500);
+
+        $this->responseMock
+            ->method('getBody')
+            ->willReturn($this->createConfiguredMock(StreamInterface::class, [
+                'getContents' => json_encode(['response' => ['reason' => 'Server Error']])
+            ]));
+
+        $this->httpClientMock
+            ->expects($this->once())
+            ->method('sendRequest')
+            ->willReturn($this->responseMock);
+
+        try {
+            $file = new UploadFile(name: 'file', contents: 'large-binary-data', filename: 'big.bin');
+            $httpClient->uploadRequest('/rest-v2/documents/upload', $file);
+            $this->fail('Expected ServerErrorException to be thrown.');
+        } catch (ServerErrorException $exception) {
+            $this->assertSame('[multipart data]', $exception->getRequestPayload());
+        }
+    }
+
+    /**
+     * @throws ServerErrorException
+     */
+    public function testUploadRequestWithStreamContents(): void
+    {
+        $psr17Factory = new Psr17Factory();
+        $httpClient = new HttpClient(
+            new TypedRequestFactory($psr17Factory),
+            $this->httpClientMock,
+            $psr17Factory
+        );
+
+        $this->responseMock
+            ->method('getStatusCode')
+            ->willReturn(200);
+
+        $this->responseMock
+            ->method('getBody')
+            ->willReturn($this->createConfiguredMock(StreamInterface::class, [
+                'getContents' => json_encode(['response' => ['code' => 200]])
+            ]));
+
+        $this->httpClientMock
+            ->expects($this->once())
+            ->method('sendRequest')
+            ->with($this->callback(function ($request): bool {
+                $request->getBody()->rewind();
+                $payload = $request->getBody()->getContents();
+
+                $this->assertStringContainsString('Content-Disposition: form-data; name="file"; filename="stream.txt"', $payload);
+                $this->assertStringContainsString('streamed-content', $payload);
+
+                return true;
+            }))
+            ->willReturn($this->responseMock);
+
+        $stream = $psr17Factory->createStream('streamed-content');
+        $file = new UploadFile(name: 'file', contents: $stream, filename: 'stream.txt');
+        $result = $httpClient->uploadRequest('/rest-v2/documents/upload', $file);
 
         $this->assertEquals(['response' => ['code' => 200]], $result);
     }

--- a/tests/Unit/Arbor/Api/Gateway/PsrRestGatewayTest.php
+++ b/tests/Unit/Arbor/Api/Gateway/PsrRestGatewayTest.php
@@ -7,6 +7,7 @@ namespace Arbor\Test\Unit\Arbor\Api\Gateway;
 use Arbor\Api\Exception\ServerErrorException;
 use Arbor\Api\Gateway\PsrRestGateway;
 use Arbor\Api\Gateway\HttpClient\HttpClientInterface;
+use Arbor\Api\Gateway\UploadFile;
 use Arbor\ChangeLog\Change;
 use Arbor\Filter\CamelCaseToDash;
 use Arbor\Filter\PluralizeFilter;
@@ -916,5 +917,26 @@ class PsrRestGatewayTest extends TestCase
 
         $this->expectException(ServerErrorException::class);
         $this->gateway->bulkCreate($resource, $collection);
+    }
+
+    /**
+     * @throws ServerErrorException
+     */
+    public function testUploadDelegatesToUploadRequest(): void
+    {
+        $file = new UploadFile(name: 'file', contents: 'file-data', filename: 'doc.pdf');
+        $expectedResponse = ['fileId' => '123'];
+
+        $this->httpClient->expects($this->once())
+            ->method('uploadRequest')
+            ->with('/rest-v2/documents/upload', $file)
+            ->willReturn($expectedResponse);
+
+        $this->httpClient->expects($this->never())
+            ->method('sendRequest');
+
+        $result = $this->gateway->upload('/rest-v2/documents/upload', $file);
+
+        $this->assertEquals($expectedResponse, $result);
     }
 }


### PR DESCRIPTION
## Summary of changes
[MIG-17813](https://orchard.atlassian.net/browse/MIG-17813)

This pull request adds support for multipart file uploads to the API SDK, allowing users to upload files (including large files via streams) using a new `upload()` method. It includes updates to the HTTP client to handle multipart requests, introduces a new `UploadFile` class, and adds comprehensive tests to ensure correct behavior and error handling.

**New multipart upload functionality:**

* Added a new `UploadFile` class to encapsulate file upload data, including support for file streams and custom headers. (`src/Arbor/Api/Gateway/UploadFile.php`)
* Introduced an `upload()` method in the `GatewayInterface` and its implementation in `PsrRestGateway` to support multipart file uploads using the new `UploadFile` class. (`src/Arbor/Api/Gateway/GatewayInterface.php`, `src/Arbor/Api/Gateway/PsrRestGateway.php`) [[1]](diffhunk://#diff-db6e922488aebc923edadee6fa353ec111294bb75c236ee2be9b2e4b67b27e0dR69-R75) [[2]](diffhunk://#diff-a8b229f9fc8e5d67a35341bd36b08f722af1ef8beab2d2d28a077b4af8d935d8R315-R339)
* Updated the HTTP client to build and send multipart/form-data requests, including validation to prevent simultaneous use of `body` and `multipart` options and to ensure multipart parts have required fields. (`src/Arbor/Api/Gateway/HttpClient/HttpClient.php`) [[1]](diffhunk://#diff-8a8639ea6710978baaf1141f8470fd6b8def3e229aacc77ea0e35a7c22c39ff7R162-R165) [[2]](diffhunk://#diff-8a8639ea6710978baaf1141f8470fd6b8def3e229aacc77ea0e35a7c22c39ff7R175) [[3]](diffhunk://#diff-8a8639ea6710978baaf1141f8470fd6b8def3e229aacc77ea0e35a7c22c39ff7L189-R226) [[4]](diffhunk://#diff-8a8639ea6710978baaf1141f8470fd6b8def3e229aacc77ea0e35a7c22c39ff7R11-R12)

**Documentation and dependency updates:**

* Updated the README with usage examples for the new multipart upload functionality, including how to upload large files using streams. (`README.md`)
* Added the `php-http/multipart-stream-builder` dependency to `composer.json` for building multipart streams. (`composer.json`)

**Testing and validation:**

* Added extensive unit tests for multipart uploads, including tests for correct request formation, error masking, multiple parts, and validation errors. (`tests/Unit/Arbor/Api/Gateway/HttpClient/HttpClientTest.php`)
* Updated test coverage annotations to include new and modified classes. (`tests/Unit/Arbor/Api/Gateway/HttpClient/HttpClientTest.php`)

These changes provide a robust and user-friendly way to handle file uploads in the SDK, with strong validation and clear documentation.

### Areas to focus on

### Notes for code owners 

### Breaking changes


[MIG-17813]: https://orchard.atlassian.net/browse/MIG-17813?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ