### PR TITLE
DOPS-18304 Bump CI actions to Node.js 24-compatible versions

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -40,7 +40,7 @@ jobs:
 
     - name: Cache Composer packages
       id: composer-cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: vendor
         key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -33,14 +33,14 @@ jobs:
       run: |
         composer config --global --auth http-basic.repo.packagist.com token ${{ secrets.PACKGIST_TOKEN }}
 
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Validate composer.json and composer.lock
       run: composer validate
 
     - name: Cache Composer packages
       id: composer-cache
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: vendor
         key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}


### PR DESCRIPTION
## Summary of changes
https://orchard.atlassian.net/browse/DOPS-18304

Bumps two GitHub Actions in `pr-build.yml` from Node.js 20 to Node.js 24-compatible versions. GitHub is deprecating Node.js 20-based actions (soft deadline June 16 2026, hard September 16 2026). All actions in the workflow were audited against their actual `using:` runtime at the pinned version tag.

| Action | From | To | Runtime change |
|---|---|---|---|
| `actions/checkout` | `@v4` (node20) | `@v6` (node24) | node20 → node24 |
| `actions/cache` | `@v3` (node20) | `@v5` (node24) | node20 → node24 |
| `shivammathur/setup-php` | `@v2` | no change | already node24 |

### Areas to focus on
- `.github/workflows/pr-build.yml` - two version pin changes

### Breaking changes

None. Both are drop-in replacements with identical inputs/outputs.