### PR TITLE
DEVX-229 Add PR housekeeping workflow

### DIFF
--- a/.github/workflows/pr-housekeeping.yaml
+++ b/.github/workflows/pr-housekeeping.yaml
@@ -1,0 +1,16 @@
+name: 'PR Housekeeping'
+on:
+  workflow_dispatch: {}
+  schedule:
+    - cron: '30 1 * * *'
+
+permissions:
+  contents: write # only for delete-branch option
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    uses: arbor-education/gha.workflows/.github/workflows/pr-housekeeping-template.yaml@v2
+    with:
+      dry_run: true

--- a/.github/workflows/pr-housekeeping.yaml
+++ b/.github/workflows/pr-housekeeping.yaml
@@ -11,6 +11,6 @@ permissions:
 
 jobs:
   stale:
-    uses: arbor-education/gha.workflows/.github/workflows/pr-housekeeping-template.yaml@v2
+    uses: arbor-education/gha.workflows/.github/workflows/pr-housekeeping-template.yaml@b2a8ca3db636abdb78177b137e3c09504582542b # v2
     with:
       dry_run: true


### PR DESCRIPTION
## Summary of changes
- [DEVX-229](https://orchard.atlassian.net/browse/DEVX-229) Deploy stale PR bot across all repositories

### Areas to focus on
- `dry_run: true` — bot will label stale PRs but **not close** them until confirmed
- Stale threshold: 30 days → label, 60 days → close (when dry_run flipped to false)

### Notes for code owners
Template source: `arbor-education/gha.workflows/.github/workflows/pr-housekeeping-template.yaml@v2`


[DEVX-229]: https://orchard.atlassian.net/browse/DEVX-229?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ